### PR TITLE
Fixing broken PR build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: trusty
 language: java
 jdk:
   - oraclejdk8


### PR DESCRIPTION
# What Changed
Fixes #5 PR build runs on trusty which is specified explicitly. https://changelog.travis-ci.com/xenial-as-the-default-build-environment-99476
# Why
PR build is broken
Todo:

- [ ] Add tests
NA
- [ ] Add docs
NA
- [ ] Add yourself to contributors (run `yarn contributors:add`)
