### PR TITLE
Multiple config files

### DIFF
--- a/.gitIgnore
+++ b/.gitIgnore
@@ -10,4 +10,4 @@ target
 *.log.*
 */*.log
 */*.log.*
-
+*/.factorypath

--- a/cloudraider-core/src/main/java/com/intuit/cloudraider/core/impl/SystemRaiderImpl.java
+++ b/cloudraider-core/src/main/java/com/intuit/cloudraider/core/impl/SystemRaiderImpl.java
@@ -29,6 +29,7 @@ import com.google.common.net.InetAddresses;
 import com.intuit.cloudraider.commons.CloudRaiderSSHSessionFactory;
 import com.intuit.cloudraider.commons.SystemDelegator;
 import com.intuit.cloudraider.core.interfaces.SystemRaider;
+import com.intuit.cloudraider.utils.ConfigUtils;
 import com.jcraft.jsch.Channel;
 import com.jcraft.jsch.ChannelExec;
 import com.jcraft.jsch.JSchException;
@@ -70,7 +71,7 @@ public class SystemRaiderImpl implements SystemRaider {
      */
     public SystemRaiderImpl() {
            }
-    
+
 
     /**
      * Execute the given script on the specified instance with parameters.
@@ -137,18 +138,14 @@ public class SystemRaiderImpl implements SystemRaider {
      * @return SessionFactory
      */
     private SessionFactory createSessionFactory(String ip) throws JSchException, IOException {
-    	
+
     	Properties prop = new Properties();
         InputStream input;
-        String configfile = System.getProperty("config.file");
-        logger.debug("System property config.file= " + configfile);
 
-        if(Strings.isNullOrEmpty(configfile)){
-            configfile = "config.properties";
-        }
+        String configfile = ConfigUtils.getConfigFilePath();
         input = ClassLoader.getSystemResourceAsStream(configfile);
         prop.load(input);
-        
+
         String skipbastion = prop.getProperty("skipbastion");
 
         InetAddresses.forString(ip);
@@ -158,7 +155,7 @@ public class SystemRaiderImpl implements SystemRaider {
 
 
         sessionFactory.addIdentityFromPrivateKey(systemDelegator.getSshParameters().getPrivateKeyPath(), systemDelegator.getSshParameters().getPassPhrase());
-        
+
         sessionFactory.printIdentities();
         Map<String,String> config = new HashMap<String, String>();
 
@@ -177,7 +174,7 @@ public class SystemRaiderImpl implements SystemRaider {
 
             logger.debug("SSH HostName: " + destinationSessionFactory.getHostname());
             logger.debug("SSH Port: " +String.valueOf(destinationSessionFactory.getPort()));
-        	
+
             return destinationSessionFactory;
         }
         else
@@ -187,7 +184,7 @@ public class SystemRaiderImpl implements SystemRaider {
 	                .setHostname( systemDelegator.getSshParameters().getBastionHost() )
 	                .setPort( SessionFactory.SSH_PORT )
 	                .build();
-	
+
 	        SessionFactory destinationSessionFactory = sessionFactory
 	                .newSessionFactoryBuilder()
 	                .setProxy( new SshProxy( proxySessionFactory ) )
@@ -195,8 +192,8 @@ public class SystemRaiderImpl implements SystemRaider {
 
             logger.debug("SSH HostName: " + destinationSessionFactory.getHostname());
             logger.debug("SSH Port: " +String.valueOf(destinationSessionFactory.getPort()));
-        	
-	
+
+
 	        return destinationSessionFactory;
         }
     }

--- a/cloudraider-core/src/main/java/com/intuit/cloudraider/model/BasicCredentials.java
+++ b/cloudraider-core/src/main/java/com/intuit/cloudraider/model/BasicCredentials.java
@@ -31,6 +31,8 @@ import com.amazonaws.services.securitytoken.AWSSecurityTokenService;
 import com.amazonaws.services.securitytoken.AWSSecurityTokenServiceClientBuilder;
 import com.amazonaws.services.securitytoken.model.AssumeRoleRequest;
 import com.google.common.base.Strings;
+import com.intuit.cloudraider.utils.ConfigUtils;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -71,7 +73,8 @@ public class BasicCredentials implements Credentials{
         Properties prop = new Properties();
         InputStream input;
         try {
-            input = ClassLoader.getSystemResourceAsStream("config.properties");
+            String configfile = ConfigUtils.getConfigFilePath();
+            input = ClassLoader.getSystemResourceAsStream(configfile);
             prop.load(input);
             prop.putAll(System.getProperties());
             region = prop.getProperty("aws.region");

--- a/cloudraider-core/src/main/java/com/intuit/cloudraider/model/SshParameters.java
+++ b/cloudraider-core/src/main/java/com/intuit/cloudraider/model/SshParameters.java
@@ -28,6 +28,8 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.Properties;
 import com.google.common.base.Strings;
+import com.intuit.cloudraider.utils.ConfigUtils;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -71,12 +73,7 @@ public class SshParameters {
 
         try {
 
-            String configfile = System.getProperty("config.file");
-            logger.debug("System property - config file=" + configfile);
-
-            if(Strings.isNullOrEmpty(configfile)){
-              configfile = "config.properties";
-            }
+            String configfile = ConfigUtils.getConfigFilePath();
             input = getClass().getClassLoader().getResourceAsStream(configfile);
 
             prop.load(input);

--- a/cloudraider-core/src/main/java/com/intuit/cloudraider/utils/ConfigUtils.java
+++ b/cloudraider-core/src/main/java/com/intuit/cloudraider/utils/ConfigUtils.java
@@ -1,0 +1,48 @@
+/*
+ * Apache 2.0 License
+ *
+ * Copyright (c) 2019 Intuit Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.intuit.cloudraider.utils;
+
+import com.google.common.base.Strings;
+
+/**
+ * Utility class to manage config files
+ */
+public class ConfigUtils {
+    /**
+     * Gets the config file path.
+     *
+     * @return the config file path
+     */
+    public static String getConfigFilePath() {
+        String configfile = System.getProperty("configFilePath");
+
+        // the default config file is config.properties
+        if (Strings.isNullOrEmpty(configfile)) {
+            configfile = "config.properties";
+        }
+
+        return configfile;
+    }
+}

--- a/cloudraider-core/src/test/java/com/intuit/cloudraider/utils/ConfigUtilsTest.java
+++ b/cloudraider-core/src/test/java/com/intuit/cloudraider/utils/ConfigUtilsTest.java
@@ -1,0 +1,50 @@
+/*
+ * Apache 2.0 License
+ *
+ * Copyright (c) 2019 Intuit Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.intuit.cloudraider.utils;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+public class ConfigUtilsTest {
+
+    /**
+     * Test getConfigFilePath utility.
+     *
+     */
+    @Test
+    public void testGetConfigFilePath() {
+        String mockedPath = "customConfigFilePath.properties";
+        System.setProperty("configFilePath", mockedPath);
+        assertEquals(mockedPath, ConfigUtils.getConfigFilePath());
+    }
+
+    @Test
+    public void testGetConfigFilePath_default() {
+        String defaultPath = "config.properties";
+        assertEquals(defaultPath, ConfigUtils.getConfigFilePath());
+    }
+}

--- a/cucumber-example/README.md
+++ b/cucumber-example/README.md
@@ -45,7 +45,7 @@ The validator uses the standard as credentials resolving chain. This means that 
 #### Eclipse
     https://shankargarg.wordpress.com/2016/05/15/integrating-eclipse-with-cucumber-natural-plugin/
 
-#### Cucumber Version 
+#### Cucumber Version
 2.3.1 is supported version for this client impletementation
 
 #### Client Confirguration with AWS credentials
@@ -69,10 +69,17 @@ if there is a passphrase for ssh key than set the property below
 ```
 aws.ec2.privateKeyPassPhrase=
 ```
+
+#### Passing a custom configuration file
+You can pass a custom configuration file by running the maven job with a `configFilePath` parameter:
+```
+mvn test -Dcucumber.options="--tags @feature1 --tags @feature2 -DconfigFilePath="customconfig.properties"
+```
+
 ## Test Execution
 
 ### Running Feature file
-Tests can be executed within IDE by execution of `*.feature` file via cucumber pluggin.  
+Tests can be executed within IDE by execution of `*.feature` file via cucumber pluggin.
 
 ### Running With TestNG
 To run a script `*.feature` file from your Java IDE, you just need the following empty test-class in the same package. The name of the class doesn't matter, and it will automatically run any `*.feature` file in the same package. This comes in useful because depending on how you organize your files and folders - you can have multiple feature files executed by a single JUnit test-class.
@@ -105,7 +112,7 @@ public class EC2FailureCucumberTest extends AbstractTestNGCucumberTests {
 Refer to your IDE documentation for how to run a JUnit class.  Typically right-clicking on the file in the project browser or even within the editor view would bring up the "Run as JUnit Test" menu option.
 
 ### HTML report
-An HTML report is output to the `target/surefire-reports` folder 
+An HTML report is output to the `target/surefire-reports` folder
 
 
 
@@ -153,7 +160,7 @@ And most convenient of all, you can even point to a directory (or package). Comb
 ## Command Line
 Normally in dev mode, you will use your IDE to run a `*.feature` file directly or via the companion 'runner' JUnit Java class. When you have a 'runner' class in place, it would be possible to run it from the command-line as well.
 
-Note that the `mvn test` command only runs test classes that follow the `*Test.java` 
+Note that the `mvn test` command only runs test classes that follow the `*Test.java`
 
 To run scenarios with @feature1 and @feature2 tags:
 ```
@@ -165,7 +172,7 @@ mvn test -Dcucumber.options="--tags @feature1,@feature2"
 ```
 
 ### Troubleshooting Cucumber IDE Support
-* On Eclipse you may see warnings such as `Step 'xxx' does not have a matching glue code` or `required(..)+ loop did not match anything at input Scenario:`, and on IntelliJ: `Unimplemented substep definition`. 
+* On Eclipse you may see warnings such as `Step 'xxx' does not have a matching glue code` or `required(..)+ loop did not match anything at input Scenario:`, and on IntelliJ: `Unimplemented substep definition`.
   ### Eclipse Solution
    Eclipse --> Preferences --> Cucumber --> User Settings
 
@@ -177,7 +184,7 @@ mvn test -Dcucumber.options="--tags @feature1,@feature2"
    If you are trying to execute Feature file than edit configuration and set glue to "com.intuit.fmea.cucumber.steps"
 
    IntelliJ 14.1.3 or higher have reported that execution fails with Exception in thread "main" java.lang.NoClassDefFoundError: org/springframework/transaction/TransactionDefinition.
-   
+
    The cause is incorrect detection of the Glue property, for some reason the package cucumber.api.spring is added incorrectly.  Edit run configuration and remove "cucumber.api.spring" from glue and make sure glue is set to "com.intuit.cloudraider.cucumber.steps"
 
 
@@ -207,18 +214,18 @@ Feature: EC2 Failure
       | ec2Name         | elbName     | alarmName                       |instanceCount |  processName   | |wait1 | wait2 | state1 | state2| expected-count1|expected-count2|
       | "hello-a-fe-e2e" | "hello-a-fe-e2e"| "hello-a-fe-e2e-UnHealthyHosts" | 1| "nginx"       | |4|4| "ALARM" | "OK"| 5  |6 |
 ```
-      
-Explanation of each of the keywords can be found at https://docs.cucumber.io/gherkin/reference/ 
+
+Explanation of each of the keywords can be found at https://docs.cucumber.io/gherkin/reference/
 
 # Step Definitions
 For each of the scenario to be processed a corresponding step definition is required. Each step definition is a java method that maps to the cucumber steps. The step definitions for the scenarios are in the Cloud-Raider library.
 
 
-## Index 
+## Index
 
-:white_small_square: | :white_small_square: | :white_small_square:  
------ | ---- | ---- 
-**AWS Resource Type** | **STEP DEFINITION** | **PURPOSE** 
+:white_small_square: | :white_small_square: | :white_small_square:
+----- | ---- | ----
+**AWS Resource Type** | **STEP DEFINITION** | **PURPOSE**
 Application Load Balancer |  ```Given ALB <string> ```| This will set the name of Application Load Balancer and fetch healthy EC2 Intances
 Classic Load Balancer |  ```Given ELB <string> ```| This will set the name of Classic Load Balancer (ELB) and fetch healthy EC2 Intances
 Network Load Balancer |  ```Given NLB <string> ```| This will set the name of Network Load Balancer and fetch healthy EC2 Intances

--- a/java-example/README.md
+++ b/java-example/README.md
@@ -31,6 +31,13 @@ if you are using passphrase
 ```
 aws.ec2.privateKeyPassPhrase=
 ```
+
+## Custom configration file
+You can pass a custom configuration file by running the maven job with a `configFilePath` parameter:
+```
+mvn test -DconfigFilePath="customconfig.properties"
+```
+
 ## How to add new Test case?
 
 Let's look an example EC2FMEATest class that invokes termination of EC2 Instance.


### PR DESCRIPTION
# What Changed
Give the users ability to pass a config file to maven using params.

It is used as follows:
```
mvn test -DconfigFilePath="customconfig.properties"
```

# Why
Issue: https://github.com/intuit/CloudRaider/issues/9
Having a single config file for multiple accounts is confusing and error prone.

Todo:

- [x] Add tests
- [x] Add docs
- [ ] Add yourself to contributors (run `yarn contributors:add`)
