### PR TITLE
Issue #35: Update the Java Version of the Core Cloud Raider Library

### DIFF
--- a/cloudraider-core/pom.xml
+++ b/cloudraider-core/pom.xml
@@ -162,7 +162,7 @@
         <dependency>
             <groupId>javax.annotation</groupId>
             <artifactId>javax.annotation-api</artifactId>
-            <version>1.3.1</version>
+            <version>1.3.2</version>
         </dependency>
 
     </dependencies>

--- a/cloudraider-core/pom.xml
+++ b/cloudraider-core/pom.xml
@@ -159,6 +159,12 @@
             <version>0.8.3</version>
         </dependency>
 
+        <dependency>
+            <groupId>javax.annotation</groupId>
+            <artifactId>javax.annotation-api</artifactId>
+            <version>1.3.1</version>
+        </dependency>
+
     </dependencies>
 
     <build>

--- a/cloudraider-core/src/main/java/com/intuit/cloudraider/utils/CommandUtility.java
+++ b/cloudraider-core/src/main/java/com/intuit/cloudraider/utils/CommandUtility.java
@@ -24,8 +24,6 @@
 
 package com.intuit.cloudraider.utils;
 
-import sun.reflect.annotation.ExceptionProxy;
-
 import java.io.IOException;
 import java.net.URISyntaxException;
 import java.nio.file.Files;

--- a/pom.xml
+++ b/pom.xml
@@ -54,6 +54,7 @@
         <jacoco.skip.instrument>false</jacoco.skip.instrument>
         <spring.version>4.3.22.RELEASE</spring.version>
         <suite>fmea-tests-all.xml</suite>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
 


### PR DESCRIPTION
# What Changed

1. Added javax.annotations dependency as these are removed from JRE in the latest Java versions
2. Added encoding property in the maven file to remove warnings.
3. Removed sun.reflect.annotations dependency(unused import) to remove the warning as these were to be removed in the future releases.

# Why

Issue: https://github.com/intuit/CloudRaider/issues/35

Todo:

- [ ] Add tests
- [ ] Add docs
- [ ] Add yourself to contributors (run `yarn contributors:add`)
